### PR TITLE
Fix filepath causing crashes on case-sensitive filesystems

### DIFF
--- a/ILSpy.Core/TreeNodes/SearchMsdnContextMenuEntry.cs
+++ b/ILSpy.Core/TreeNodes/SearchMsdnContextMenuEntry.cs
@@ -23,7 +23,7 @@ using ICSharpCode.ILSpy.Properties;
 
 namespace ICSharpCode.ILSpy.TreeNodes
 {
-    [ExportContextMenuEntry(Header = nameof(Resources.SearchMSDN), Icon = "images/SearchMsdn.png", Order = 9999)]
+    [ExportContextMenuEntry(Header = nameof(Resources.SearchMSDN), Icon = "Images/SearchMsdn.png", Order = 9999)]
     internal sealed class SearchMsdnContextMenuEntry : IContextMenuEntry
     {
         private static string msdnAddress = "http://msdn.microsoft.com/{1}/library/{0}";


### PR DESCRIPTION
Getting a crash while right-clicking a subfolder under a root in the tree. Error said 

 ```
Sorry, we crashed
System.IO.DirectoryNotFoundException: Could not find a part of the path '/usr/share/avaloniailspy/images/SearchMsdn.png'.
...
```

Fixed it to `Images/SearchMsdn.png` and then it worked. 