### PR TITLE
Publish for win-x64 instead of win7-x64

### DIFF
--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -7,7 +7,7 @@
     <TieredCompilation>true</TieredCompilation>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>


### PR DESCRIPTION
When publishing for Win7 some extra, unneeded files are included.
Among them, the System.Private.CoreLib.ni.dll from .NET Core 1.0
is included. It appears the depenencies are coming from SharpDX.
For reasons I have not figured out, publishing with win-x64 instead
does not include these extra files.

Publishing a .NET Core 3.1 Windows Forms application with both
win7-64 and win-64 does not show in difference in the number of files
included. So I assumed that there is a bug in the .NET Core CLI or
NuGet that causes these extra, unneeded files to be included.

This reduces the size of the published application for windows from
115 MB to 102MB, before compression.