### PR TITLE
M1 Support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <AvaloniaVersion>0.10.10</AvaloniaVersion>
+        <AvaloniaVersion>0.10.11</AvaloniaVersion>
         <AvaloniaEditVersion>0.10.9</AvaloniaEditVersion>
     </PropertyGroup>
 

--- a/ILSpy.Core/TextView/CaretHighlightAdorner.cs
+++ b/ILSpy.Core/TextView/CaretHighlightAdorner.cs
@@ -84,7 +84,7 @@ namespace ICSharpCode.ILSpy.TextView
                 }
             };
 
-            caretAnimation.RunAsync(this);
+            caretAnimation.RunAsync(this, null, default);
         }
 
         public static void DisplayCaretHighlightAnimation(TextArea textArea)

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -7,7 +7,7 @@
     <TieredCompilation>true</TieredCompilation>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
@@ -56,11 +56,21 @@
     </Content>
   </ItemGroup>
 
+    <ItemGroup Condition="'$(RuntimeIdentifier)' == 'osx-arm64'">
+    <Content Include="ILSpy.icns">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Info.plist">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\ILSpy.Core\ILSpy.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="SkiaSharp" Version="2.88.0-preview.179" />
   </ItemGroup>
 </Project>

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -71,6 +71,5 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="SkiaSharp" Version="2.88.0-preview.179" />
   </ItemGroup>
 </Project>

--- a/nuget.config
+++ b/nuget.config
@@ -5,5 +5,6 @@
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="AvaloniaCI" value="https://www.myget.org/F/avalonia-ci/api/v2" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+    <add key="skiasharp-eap" value="https://aka.ms/skiasharp-eap/index.json" />
   </packageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -5,6 +5,5 @@
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="AvaloniaCI" value="https://www.myget.org/F/avalonia-ci/api/v2" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-    <add key="skiasharp-eap" value="https://aka.ms/skiasharp-eap/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
<details>
<summary>Try newer Skia but didn't work</summary>

Using

![image](https://user-images.githubusercontent.com/344208/147549143-2c340c6e-4492-4bc9-9406-f948f1f201b9.png)



</details>

```
Sorry, we crashed
Microsoft.VisualStudio.Composition.CompositionFailedException: An exception was thrown while initializing part "ICSharpCode.ILSpy.TextView.DecompilerTextView".
 ---> System.DllNotFoundException: Unable to load shared library 'libHarfBuzzSharp' or one of its dependencies. In order to help diagnose loading problems, consider setting the DYLD_PRINT_LIBRARIES environment variable: dlopen(liblibHarfBuzzSharp, 0x0001): tried: 'liblibHarfBuzzSharp' (no such file), '/usr/local/lib/liblibHarfBuzzSharp' (no such file), '/usr/lib/liblibHarfBuzzSharp' (no such file), '/Users/christophw/GitWorkspace/AvaloniaILSpy/ILSpy/bin/Debug/net6.0/liblibHarfBuzzSharp' (no such file), '/usr/local/lib/liblibHarfBuzzSharp' (no such file), '/usr/lib/liblibHarfBuzzSharp' (no such file)
   at HarfBuzzSharp.HarfBuzzApi.hb_face_create_for_tables(GetTableDelegateProxyDelegate reference_table_func, IntPtr user_data, ReleaseDelegateProxyDelegate destroy)
   at HarfBuzzSharp.Face..ctor(GetTableDelegate getTable, ReleaseDelegate destroy)
   at HarfBuzzSharp.Face..ctor(GetTableDelegate getTable)
   at Avalonia.Skia.GlyphTypefaceImpl..ctor(SKTypeface typeface, Boolean isFakeBold, Boolean isFakeItalic) in /_/src/Skia/Avalonia.Skia/GlyphTypefaceImpl.cs:line 17
   at Avalonia.Skia.FontManagerImpl.CreateGlyphTypeface(Typeface typeface) in /_/src/Skia/Avalonia.Skia/FontManagerImpl.cs:line 147
   at Avalonia.Media.FontManager.GetOrAddGlyphTypeface(Typeface typeface) in /_/src/Avalonia.Visuals/Media/FontManager.cs:line 89
   at Avalonia.Skia.FormattedTextImpl..ctor(String text, Typeface typeface, Double fontSize, TextAlignment textAlignment, TextWrapping wrapping, Size constraint, IReadOnlyList`1 spans) in /_/src/Skia/Avalonia.Skia/FormattedTextImpl.cs:line 25
   at Avalonia.Skia.PlatformRenderInterface.CreateFormattedText(String text, Typeface typeface, Double fontSize, TextAlignment textAlignment, TextWrapping wrapping, Size constraint, IReadOnlyList`1 spans) in /_/src/Skia/Avalonia.Skia/PlatformRenderInterface.cs:line 50
   at Avalonia.Media.FormattedText.get_PlatformImpl() in /_/src/Avalonia.Visuals/Media/FormattedText.cs:line 143
   at Avalonia.Media.FormattedText.get_Bounds() in /_/src/Avalonia.Visuals/Media/FormattedText.cs:line 67
   at AvaloniaEdit.Text.TextLineRun.CreateRunForText(StringRange stringRange, TextRun textRun, Double widthLeft, Boolean emergencyWrap, Boolean breakOnTabs)
   at AvaloniaEdit.Text.TextLineRun.Create(TextSource textSource, StringRange stringRange, TextRun textRun, Int32 index, Double widthLeft)
   at AvaloniaEdit.Text.TextLineRun.Create(TextSource textSource, Int32 index, Int32 firstIndex, Double lengthLeft)
   at AvaloniaEdit.Text.TextLineImpl.Create(TextParagraphProperties paragraphProperties, Int32 firstIndex, Int32 paragraphLength, TextSource textSource)
   at AvaloniaEdit.Text.TextFormatter.FormatLine(TextSource textSource, Int32 firstCharIndex, Double paragraphWidth, TextParagraphProperties paragraphProperties)
   at AvaloniaEdit.Rendering.TextView.CalculateDefaultTextMetrics()
   at AvaloniaEdit.Rendering.TextView.get_DefaultLineHeight()
   at AvaloniaEdit.Rendering.TextView.OnDocumentChanged(TextDocument oldValue, TextDocument newValue)
   at AvaloniaEdit.Rendering.TextView.OnDocumentChanged(AvaloniaPropertyChangedEventArgs e)
   at System.Reactive.AnonymousObserver`1.OnNextCore(T value) in /_/Rx.NET/Source/src/System.Reactive/AnonymousObserver.cs:line 67
   at System.Reactive.ObserverBase`1.OnNext(T value) in /_/Rx.NET/Source/src/System.Reactive/ObserverBase.cs:line 34
   at System.Reactive.Subjects.Subject`1.OnNext(T value) in /_/Rx.NET/Source/src/System.Reactive/Subjects/Subject.cs:line 145
   at Avalonia.AvaloniaObject.RaisePropertyChanged[T](AvaloniaPropertyChangedEventArgs`1 change) in /_/src/Avalonia.Base/AvaloniaObject.cs:line 758
   at Avalonia.AvaloniaObject.Avalonia.PropertyStore.IValueSink.ValueChanged[T](AvaloniaPropertyChangedEventArgs`1 change) in /_/src/Avalonia.Base/AvaloniaObject.cs:line 533
   at Avalonia.ValueStore.NotifyValueChanged[T](AvaloniaProperty`1 property, Optional`1 oldValue, BindingValue`1 newValue, BindingPriority priority) in /_/src/Avalonia.Base/ValueStore.cs:line 356
   at Avalonia.ValueStore.SetValue[T](StyledPropertyBase`1 property, T value, BindingPriority priority) in /_/src/Avalonia.Base/ValueStore.cs:line 123
   at Avalonia.AvaloniaObject.SetValue[T](StyledPropertyBase`1 property, T value, BindingPriority priority) in /_/src/Avalonia.Base/AvaloniaObject.cs:line 369
   at AvaloniaEdit.Rendering.TextView.set_Document(TextDocument value)
   at AvaloniaEdit.Editing.TextArea.OnDocumentChanged(TextDocument oldValue, TextDocument newValue)
   at AvaloniaEdit.Editing.TextArea.OnDocumentChanged(AvaloniaPropertyChangedEventArgs e)
   at System.Reactive.AnonymousObserver`1.OnNextCore(T value) in /_/Rx.NET/Source/src/System.Reactive/AnonymousObserver.cs:line 67
   at System.Reactive.ObserverBase`1.OnNext(T value) in /_/Rx.NET/Source/src/System.Reactive/ObserverBase.cs:line 34
   at System.Reactive.Subjects.Subject`1.OnNext(T value) in /_/Rx.NET/Source/src/System.Reactive/Subjects/Subject.cs:line 145
   at Avalonia.AvaloniaObject.RaisePropertyChanged[T](AvaloniaPropertyChangedEventArgs`1 change) in /_/src/Avalonia.Base/AvaloniaObject.cs:line 758
   at Avalonia.AvaloniaObject.Avalonia.PropertyStore.IValueSink.ValueChanged[T](AvaloniaPropertyChangedEventArgs`1 change) in /_/src/Avalonia.Base/AvaloniaObject.cs:line 533
   at Avalonia.ValueStore.NotifyValueChanged[T](AvaloniaProperty`1 property, Optional`1 oldValue, BindingValue`1 newValue, BindingPriority priority) in /_/src/Avalonia.Base/ValueStore.cs:line 356
   at Avalonia.ValueStore.SetValue[T](StyledPropertyBase`1 property, T value, BindingPriority priority) in /_/src/Avalonia.Base/ValueStore.cs:line 123
   at Avalonia.AvaloniaObject.SetValue[T](StyledPropertyBase`1 property, T value, BindingPriority priority) in /_/src/Avalonia.Base/AvaloniaObject.cs:line 369
   at AvaloniaEdit.Editing.TextArea.set_Document(TextDocument value)
   at AvaloniaEdit.TextEditor.OnDocumentChanged(TextDocument oldValue, TextDocument newValue)
   at AvaloniaEdit.TextEditor.OnDocumentChanged(AvaloniaPropertyChangedEventArgs e)
   at System.Reactive.AnonymousObserver`1.OnNextCore(T value) in /_/Rx.NET/Source/src/System.Reactive/AnonymousObserver.cs:line 67
   at System.Reactive.ObserverBase`1.OnNext(T value) in /_/Rx.NET/Source/src/System.Reactive/ObserverBase.cs:line 34
   at System.Reactive.Subjects.Subject`1.OnNext(T value) in /_/Rx.NET/Source/src/System.Reactive/Subjects/Subject.cs:line 145
   at Avalonia.AvaloniaObject.RaisePropertyChanged[T](AvaloniaPropertyChangedEventArgs`1 change) in /_/src/Avalonia.Base/AvaloniaObject.cs:line 758
   at Avalonia.AvaloniaObject.Avalonia.PropertyStore.IValueSink.ValueChanged[T](AvaloniaPropertyChangedEventArgs`1 change) in /_/src/Avalonia.Base/AvaloniaObject.cs:line 533
   at Avalonia.ValueStore.NotifyValueChanged[T](AvaloniaProperty`1 property, Optional`1 oldValue, BindingValue`1 newValue, BindingPriority priority) in /_/src/Avalonia.Base/ValueStore.cs:line 356
   at Avalonia.ValueStore.SetValue[T](StyledPropertyBase`1 property, T value, BindingPriority priority) in /_/src/Avalonia.Base/ValueStore.cs:line 123
   at Avalonia.AvaloniaObject.SetValue[T](StyledPropertyBase`1 property, T value, BindingPriority priority) in /_/src/Avalonia.Base/AvaloniaObject.cs:line 369
   at AvaloniaEdit.TextEditor..ctor(TextArea textArea, TextDocument document)
   at AvaloniaEdit.TextEditor..ctor(TextArea textArea)
   at AvaloniaEdit.TextEditor..ctor()
   at ICSharpCode.ILSpy.TextView.DecompilerTextView.!XamlIlPopulate(IServiceProvider , DecompilerTextView ) in /Users/christophw/GitWorkspace/AvaloniaILSpy/ILSpy.Core/TextView/DecompilerTextView.xaml:line 10
   at ICSharpCode.ILSpy.TextView.DecompilerTextView.!XamlIlPopulateTrampoline(DecompilerTextView )
   at ICSharpCode.ILSpy.TextView.DecompilerTextView.InitializeComponent() in /Users/christophw/GitWorkspace/AvaloniaILSpy/ILSpy.Core/TextView/DecompilerTextView.xaml.cs:line 128
   at ICSharpCode.ILSpy.TextView.DecompilerTextView..ctor() in /Users/christophw/GitWorkspace/AvaloniaILSpy/ILSpy.Core/TextView/DecompilerTextView.xaml.cs:line 89
   --- End of inner exception stack trace ---
   at Microsoft.VisualStudio.Composition.RuntimeExportProviderFactory.RuntimeExportProvider.RuntimePartLifecycleTracker.CreateValue()
   at Microsoft.VisualStudio.Composition.ExportProvider.PartLifecycleTracker.Create()
   at Microsoft.VisualStudio.Composition.ExportProvider.PartLifecycleTracker.MoveNext(PartLifecycleState nextState)
   at Microsoft.VisualStudio.Composition.ExportProvider.PartLifecycleTracker.MoveToState(PartLifecycleState requiredState)
   at Microsoft.VisualStudio.Composition.ExportProvider.PartLifecycleTracker.GetValueReadyToExpose()
   at Microsoft.VisualStudio.Composition.ExportProvider.<>c__DisplayClass55_0.<CreateExport>b__0()
   at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)
   at System.Lazy`1.ExecutionAndPublication(LazyHelper executionAndPublication, Boolean useDefaultConstructor)
   at System.Lazy`1.CreateValue()
   at System.Lazy`1.get_Value()
   at Microsoft.VisualStudio.Composition.Export.get_Value()
   at Microsoft.VisualStudio.Composition.ExportProvider.<>c__DisplayClass71_1`2.<GetExports>b__1()
   at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)
   at System.Lazy`1.ExecutionAndPublication(LazyHelper executionAndPublication, Boolean useDefaultConstructor)
   at System.Lazy`1.CreateValue()
   at System.Lazy`1.get_Value()
   at Microsoft.VisualStudio.Composition.ExportProvider.GetExportedValue[T]()
   at ICSharpCode.ILSpy.MainWindow..ctor() in /Users/christophw/GitWorkspace/AvaloniaILSpy/ILSpy.Core/MainWindow.xaml.cs:line 133
   at ICSharpCode.ILSpy.App.OnFrameworkInitializationCompleted() in /Users/christophw/GitWorkspace/AvaloniaILSpy/ILSpy.Core/App.xaml.cs:line 133
   at Avalonia.Controls.AppBuilderBase`1.Setup() in /_/src/Avalonia.Controls/AppBuilderBase.cs:line 312
   at Avalonia.Controls.AppBuilderBase`1.SetupWithLifetime(IApplicationLifetime lifetime) in /_/src/Avalonia.Controls/AppBuilderBase.cs:line 179
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime[T](T builder, String[] args, ShutdownMode shutdownMode) in /_/src/Avalonia.Controls/ApplicationLifetimes/ClassicDesktopStyleApplicationLifetime.cs:line 174
   at ICSharpCode.ILSpy.Program.Main(String[] args) in /Users/christophw/GitWorkspace/AvaloniaILSpy/ILSpy/Program.cs:line 22
```