### PR TITLE
Fix Save Code context menu option

### DIFF
--- a/ILSpy.Core/Commands/SaveCodeContextMenuEntry.cs
+++ b/ILSpy.Core/Commands/SaveCodeContextMenuEntry.cs
@@ -104,7 +104,7 @@ namespace ICSharpCode.ILSpy.TextView
             };
 
             string filename = await dlg.ShowAsync(MainWindow.Instance);
-            if (filename != null)
+            if (filename == null)
             {
                 return null;
             }


### PR DESCRIPTION
This context menu option did not save the solution even if a filename was selected. Now it does.
Fixes #101.