### PR TITLE
Fix saving C# project into a single file | #66

### DIFF
--- a/ILSpy.Core/TreeNodes/AssemblyTreeNode.cs
+++ b/ILSpy.Core/TreeNodes/AssemblyTreeNode.cs
@@ -319,6 +319,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 			SaveFileDialog dlg = new SaveFileDialog();
 			dlg.Title = "Save file";
             dlg.InitialFileName = DecompilerTextView.CleanUpName(LoadedAssembly.ShortName);
+			dlg.DefaultExtension = language.ProjectFileExtension;
 			dlg.Filters = new List<FileDialogFilter>() 
 			{
                 new FileDialogFilter() { Name = language.Name + " project", Extensions = { language.ProjectFileExtension.TrimStart('.') } },


### PR DESCRIPTION
Just saw #66 and how nemec commented the responsible line for that behavior.
I haven't really spent enough time with the code to confidently say that this works for every invocation of the Save() method.
But since there are filters for single and project files, I'm not really sure if my solution is good enough.

While debugging I couldn't figure out how to get the save dialog of this method to open for anything else than for saving a project, so I decided to leave it that way and PR it.