### PR TITLE
Fix assembly path argument for Linux platforms.

### DIFF
--- a/ILSpy.Core/CommandLineArguments.cs
+++ b/ILSpy.Core/CommandLineArguments.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace ICSharpCode.ILSpy
 {
@@ -52,6 +53,8 @@ namespace ICSharpCode.ILSpy
 						this.NoActivate = true;
 					else if (arg.StartsWith("/config:", StringComparison.OrdinalIgnoreCase))
 						this.ConfigFile = arg.Substring("/config:".Length);
+					else if (Path.DirectorySeparatorChar == '/' && File.Exists(arg))
+					 	this.AssembliesToLoad.Add(arg);
 				}
 				else {
 					this.AssembliesToLoad.Add(arg);


### PR DESCRIPTION
This PR fixes loading of assembly by startup arguments when using absolute paths on linux platform that uses '/' as root path.
Relative paths still not working because of [this](https://github.com/icsharpcode/AvaloniaILSpy/blob/5f0f23169e921286f4233c1d290270f061117982/ILSpy/Program.cs#L18) that changes cwd.