### PR TITLE
Minimal update to decompilation engine 8.0.0.7345

### DIFF
--- a/ICSharpCode.Decompiler.PdbProvider.Cecil/ICSharpCode.Decompiler.PdbProvider.Cecil.csproj
+++ b/ICSharpCode.Decompiler.PdbProvider.Cecil/ICSharpCode.Decompiler.PdbProvider.Cecil.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.11.3" />
-    <PackageReference Include="ICSharpCode.Decompiler" Version="8.0.0.7106-preview2" />
+    <PackageReference Include="ICSharpCode.Decompiler" Version="8.0.0.7345" />
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
     <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />

--- a/ILSpy.Core/ILSpy.Core.csproj
+++ b/ILSpy.Core/ILSpy.Core.csproj
@@ -29,7 +29,7 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="ICSharpCode.Decompiler" Version="8.0.0.7106-preview2" />
+    <PackageReference Include="ICSharpCode.Decompiler" Version="8.0.0.7345" />
     <PackageReference Include="Microsoft.DiaSymReader" Version="1.4.0" />
     <PackageReference Include="Microsoft.DiaSymReader.Converter.Xml" Version="1.1.0-beta2-22164-02" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="17.1.20" />

--- a/ILSpy.Core/Languages/CSharpLanguage.cs
+++ b/ILSpy.Core/Languages/CSharpLanguage.cs
@@ -332,7 +332,8 @@ namespace ICSharpCode.ILSpy
                 return;
             string line1 = Properties.Resources.WarningSomeAssemblyReference;
             string line2 = Properties.Resources.PropertyManuallyMissingReferencesListLoadedAssemblies;
-            AddWarningMessage(module, output, line1, line2, Properties.Resources.ShowAssemblyLoad, Images.ViewCode, delegate {
+            AddWarningMessage(module, output, line1, line2, Properties.Resources.ShowAssemblyLoad, Images.ViewCode, delegate
+            {
                 ILSpyTreeNode assemblyNode = MainWindow.Instance.FindTreeNode(module);
                 assemblyNode.EnsureLazyChildren();
                 MainWindow.Instance.SelectNode(assemblyNode.Children.OfType<ReferenceFolderTreeNode>().Single());
@@ -485,17 +486,18 @@ namespace ICSharpCode.ILSpy
             readonly DecompilationOptions options;
 
             public ILSpyWholeProjectDecompiler(LoadedAssembly assembly, DecompilationOptions options)
-            : base (
-                options.DecompilerSettings, 
-                assembly.GetAssemblyResolver (),
+            : base(
+                options.DecompilerSettings,
+                assembly.GetAssemblyResolver(),
                 null,
-                assembly.GetDebugInfoOrNull ()
-            ) {
+                assembly.GetDebugInfoOrNull()
+            )
+            {
                 this.assembly = assembly;
                 this.options = options;
             }
 
-            protected override IEnumerable<(string itemType, string fileName, List<PartialTypeInfo> partialTypes)> WriteResourceToFile(string fileName, string resourceName, Stream entryStream)
+            protected override IEnumerable<ProjectItemInfo> WriteResourceToFile(string fileName, string resourceName, Stream entryStream)
             {
                 foreach (var handler in App.ExportProvider.GetExportedValues<IResourceFileHandler>())
                 {
@@ -503,7 +505,7 @@ namespace ICSharpCode.ILSpy
                     {
                         entryStream.Position = 0;
                         fileName = handler.WriteResourceToFile(assembly, fileName, entryStream, options);
-                        return new[] { (handler.EntryType, fileName, (List<PartialTypeInfo>)null) };
+                        return new[] { new ProjectItemInfo(handler.EntryType, fileName) };
                     }
                 }
                 return base.WriteResourceToFile(fileName, resourceName, entryStream);

--- a/ILSpy.Core/Properties/AssemblyInfo.cs
+++ b/ILSpy.Core/Properties/AssemblyInfo.cs
@@ -16,7 +16,7 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: AssemblyDescription(".NET assembly inspector and decompiler")]
 [assembly: AssemblyCompany("ic#code")]
 [assembly: AssemblyProduct("ILSpy")]
-[assembly: AssemblyCopyright("Copyright 2011-2019 AlphaSierraPapa for the SharpDevelop Team")]
+[assembly: AssemblyCopyright("Copyright 2011-2023 AlphaSierraPapa for the SharpDevelop Team")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -39,7 +39,7 @@ internal static class RevisionClass
 	public const string Minor = "0";
 	public const string Build = "0";
 	public const string Revision = "0";
-	public const string VersionName = "preview2";
+	public const string VersionName = "preview3";
 	
 	public const string FullVersion = Major + "." + Minor + "." + Build + "." + Revision + "." + VersionName;
 }

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "6.0.200",
+    "rollForward": "major",
+    "allowPrerelease": true
+  }
+}


### PR DESCRIPTION
Intent: together with the Avalonia 11 update, dmg publishing (although not fully functional) and an issue triage ship "as is" because that is way better than the current binaries - and then go to 8.1 with ILSpyX.