### PR TITLE
Fix crash if SpecialFolder.ApplicationData doesn't exist

### DIFF
--- a/ILSpy.Core/ILSpySettings.cs
+++ b/ILSpy.Core/ILSpySettings.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright (c) 2011 AlphaSierraPapa for the SharpDevelop Team
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
 // without restriction, including without limitation the rights to use, copy, modify, merge,
 // publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
 // to whom the Software is furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all copies or
 // substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
 // INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
 // PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
@@ -30,23 +30,23 @@ namespace ICSharpCode.ILSpy
 	public class ILSpySettings
 	{
 		readonly XElement root;
-		
+
 		ILSpySettings()
 		{
 			this.root = new XElement("ILSpy");
 		}
-		
+
 		ILSpySettings(XElement root)
 		{
 			this.root = root;
 		}
-		
+
 		public XElement this[XName section] {
 			get {
 				return root.Element(section) ?? new XElement(section);
 			}
 		}
-		
+
 		/// <summary>
 		/// Loads the settings file from disk.
 		/// </summary>
@@ -66,12 +66,12 @@ namespace ICSharpCode.ILSpy
 				}
 			}
 		}
-		
+
 		static XDocument LoadWithoutCheckingCharacters(string fileName)
 		{
 			return XDocument.Load(fileName, LoadOptions.None);
 		}
-		
+
 		/// <summary>
 		/// Saves a setting section.
 		/// </summary>
@@ -86,7 +86,7 @@ namespace ICSharpCode.ILSpy
 						root.Add(section);
 				});
 		}
-		
+
 		/// <summary>
 		/// Updates the saved settings.
 		/// We always reload the file on updates to ensure we aren't overwriting unrelated changes performed
@@ -111,7 +111,7 @@ namespace ICSharpCode.ILSpy
 				doc.Save(config, SaveOptions.None);
 			}
 		}
-		
+
 		static string GetConfigFile()
 		{
 			if (App.CommandLineArguments.ConfigFile != null)
@@ -119,18 +119,18 @@ namespace ICSharpCode.ILSpy
 			string localPath = Path.Combine(AppContext.BaseDirectory, "ILSpy.xml");
 			if (File.Exists(localPath))
 				return localPath;
-			return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "ILSpy.xml");
+			return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.DoNotVerify), "ILSpy.xml");
 		}
-		
+
 		const string ConfigFileMutex = "01A91708-49D1-410D-B8EB-4DE2662B3971";
-		
+
 		/// <summary>
 		/// Helper class for serializing access to the config file when multiple ILSpy instances are running.
 		/// </summary>
 		sealed class MutexProtector : IDisposable
 		{
 			readonly Mutex mutex;
-			
+
 			public MutexProtector(string name)
 			{
 				bool createdNew;
@@ -142,7 +142,7 @@ namespace ICSharpCode.ILSpy
 					}
 				}
 			}
-			
+
 			public void Dispose()
 			{
 				mutex.ReleaseMutex();


### PR DESCRIPTION
If the folder doesn't exist, the config variable will be 'ILSpy.xml', and the parent directory name will be an empty string. This will cause CreateDirectory to throw, and the application to potentially crash due to an exception in a background thread. This manifests as a native crash, NSInternalInconsistencyException, on my machine, with the message 'Terminating app due to uncaught exception
'NSInternalInconsistencyException',reason: 'NSWindow drag regions should only be invalidated on the Main Thread'.

By passing 'DoNotVerify' to Environment.GetFolderPath we can avoid the check for directory existence and avoid the crash.