### PR TITLE
Fix issues with history navigation - entries not getting selected correctly, duplicate text in decompiler output

### DIFF
--- a/SharpTreeView/TreeFlattener.cs
+++ b/SharpTreeView/TreeFlattener.cs
@@ -9,7 +9,7 @@ using System.Diagnostics;
 
 namespace ICSharpCode.TreeView
 {
-	sealed class TreeFlattener : IList, INotifyCollectionChanged
+	sealed class TreeFlattener : IList, IList<object>, INotifyCollectionChanged
 	{
 		/// <summary>
 		/// The root node of the flat list tree.
@@ -88,7 +88,7 @@ namespace ICSharpCode.TreeView
 			}
 		}
 		
-		bool IList.IsReadOnly {
+		public bool IsReadOnly {
 			get { return true; }
 		}
 		
@@ -106,12 +106,12 @@ namespace ICSharpCode.TreeView
 			}
 		}
 		
-		void IList.Insert(int index, object item)
+		public void Insert(int index, object item)
 		{
 			throw new NotSupportedException();
 		}
 		
-		void IList.RemoveAt(int index)
+		public void RemoveAt(int index)
 		{
 			throw new NotSupportedException();
 		}
@@ -121,7 +121,12 @@ namespace ICSharpCode.TreeView
 			throw new NotSupportedException();
 		}
 		
-		void IList.Clear()
+		public void Add(object item)
+		{
+			throw new NotSupportedException();
+		}
+		
+		public void Clear()
 		{
 			throw new NotSupportedException();
 		}
@@ -137,12 +142,30 @@ namespace ICSharpCode.TreeView
 				array.SetValue(item, arrayIndex++);
 		}
 		
+		public void CopyTo(object[] array, int arrayIndex)
+		{
+			foreach (object item in this)
+				array.SetValue(item, arrayIndex++);
+		}
+		
 		void IList.Remove(object item)
 		{
 			throw new NotSupportedException();
 		}
 		
+		public bool Remove(object item)
+		{
+			throw new NotSupportedException();
+		}
+		
 		public IEnumerator GetEnumerator()
+		{
+			for (int i = 0; i < this.Count; i++) {
+				yield return this[i];
+			}
+		}
+		
+		IEnumerator<object> IEnumerable<object>.GetEnumerator()
 		{
 			for (int i = 0; i < this.Count; i++) {
 				yield return this[i];


### PR DESCRIPTION
Fixes the following two (related) issues:
- After selecting entry A, then entry B, going back in history, and reselecting entry B, the decompiler output will now include both the results for A and B concatenated together. The results for A then persist when selecting any other entry, appearing above the decompilation for the actually selected entry.
- After selecting entry A, then entry B, and going back in history, entry A does not appear to be selected on the list.

This PR changes `TreeFlattener` to implement `IList<object>`.
The cause of the issue is the following line in Avalonia: [SelectionModel.cs#L36](https://github.com/AvaloniaUI/Avalonia/blob/0.10.13/src/Avalonia.Controls/Selection/SelectionModel.cs#L36)
Specifically, when changing the selection programmatically, the `SelectionModel` tries to find the indices of any entries added to the selection in the source, to generate the ranges. However, since the source is casted to `IEnumerable<object>` here, casting the `TreeFlattener` results in `null`, causing the `SelectionModel` to abort updating the selection.'

Might be superseded by:
- https://github.com/icsharpcode/AvaloniaILSpy/pull/141

Looks like an update to Avalonia might fix this issue: [ba7e8a2](https://github.com/AvaloniaUI/Avalonia/commit/ba7e8a20b5cd7e67f536dfe782e10972eda761ae#diff-6f5b4867403f224d22e1fbed6f0bcdec0a611944ffe9a58d2e005482a6b7c0e5L33-L35)
It seems like the current master branch uses `IEnumerable` instead of `IEnumerable<T>`, which should sidestep the problem.
