### PR TITLE
Fix searchbox selection highlighting

### DIFF
--- a/ILSpy.Core/Controls/SearchBox.xaml
+++ b/ILSpy.Core/Controls/SearchBox.xaml
@@ -8,7 +8,9 @@
 		<Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
 		<Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderMidBrush}" />
 		<Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
-        <Setter Property="BorderThickness" Value="1" />
+		<Setter Property="BorderThickness" Value="1" />
+		<Setter Property="SelectionBrush" Value="{DynamicResource HighlightBrush}"/>
+		<Setter Property="SelectionForegroundBrush" Value="{DynamicResource HighlightForegroundBrush}"/>
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate>
@@ -39,7 +41,9 @@
                                              SelectionEnd="{TemplateBinding SelectionEnd}"
                                              TextAlignment="{TemplateBinding TextAlignment}"
                                              TextWrapping="{TemplateBinding TextWrapping}"
-                                             PasswordChar="{TemplateBinding PasswordChar}"/>
+                                             PasswordChar="{TemplateBinding PasswordChar}"
+                                             SelectionBrush="{TemplateBinding SelectionBrush}"
+                                             SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"/>
                             </Panel>
                           </ScrollViewer>
               


### PR DESCRIPTION
Based on [TextBox.xaml](https://github.com/AvaloniaUI/Avalonia/blob/0.10.13/src/Avalonia.Themes.Default/TextBox.xaml) from Avalonia.
Fixes search box not showing any indication on what text is selected.

I'm unsure of why this is an issue, when it broke (or if it was never fixed since the Avalonia port), but it seems like the option to set the brushes for the selection was added in 2019 - I'm assuming this was missed at some point when updating Avalonia.
Side note: I noticed the indentation in the file is very inconsistent, but I decided to leave it as is for this and indent the same as adjacent code.

Before:
![image](https://github.com/icsharpcode/AvaloniaILSpy/assets/6917698/26c2600e-69f7-4d26-a81a-c5cea137cf41)

After:
![image](https://github.com/icsharpcode/AvaloniaILSpy/assets/6917698/02a5d43a-dc4d-4e50-8084-a7613b75cc28)
