### PR TITLE
Bump ILSpy to NET8

### DIFF
--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>WinExe</OutputType>
 
     <TieredCompilation>true</TieredCompilation>


### PR DESCRIPTION
As the title suggests, this PR updates ILSpy project to NET8.